### PR TITLE
refactor: replace logo grid with text cards

### DIFF
--- a/components/IntegrationsStrip.tsx
+++ b/components/IntegrationsStrip.tsx
@@ -1,48 +1,44 @@
-import Image from "next/image"
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 
-const logos = [
+const integrations = [
   {
-    src: "/integrations/appfolio.svg",
-    alt: "AppFolio logo",
-    text: "AppFolio • sync availability & pricing",
+    name: "AppFolio",
+    description: "Sync availability & pricing",
   },
   {
-    src: "/integrations/buildium.svg",
-    alt: "Buildium logo",
-    text: "Buildium • sync availability & pricing",
+    name: "Buildium",
+    description: "Sync availability & pricing",
   },
   {
-    src: "/integrations/yardi.svg",
-    alt: "Yardi logo",
-    text: "Yardi • push tours & log leads",
+    name: "Yardi",
+    description: "Push tours & log leads",
   },
   {
-    src: "/integrations/google-calendar.svg",
-    alt: "Google Calendar logo",
-    text: "Google Calendar • real-time scheduling",
+    name: "Google Calendar",
+    description: "Real-time scheduling",
   },
   {
-    src: "/integrations/twilio.svg",
-    alt: "Twilio logo",
-    text: "Twilio • SMS & handoff",
+    name: "Twilio",
+    description: "SMS & handoff",
   },
   {
-    src: "/integrations/hubspot.svg",
-    alt: "HubSpot logo",
-    text: "HubSpot • lead capture & tracking",
+    name: "HubSpot",
+    description: "Lead capture & tracking",
   },
 ]
 
 export function IntegrationsStrip() {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8 items-center">
-      {logos.map((logo) => (
-        <div key={logo.src} className="flex items-center justify-center">
-          <div className="text-center">
-            <Image src={logo.src} alt={logo.alt} width={120} height={40} loading="lazy" />
-            <p className="mt-2 text-sm text-zinc-600">{logo.text}</p>
-          </div>
-        </div>
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {integrations.map((integration) => (
+        <Card key={integration.name} className="text-center">
+          <CardHeader className="items-center p-4 text-center">
+            <CardTitle className="text-base font-medium">
+              {integration.name}
+            </CardTitle>
+            <CardDescription>{integration.description}</CardDescription>
+          </CardHeader>
+        </Card>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- remove integration logos and switch to text-only cards

## Testing
- `pnpm lint` *(fails: interactive ESLint configuration prompt)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689d1d9aa4c883219d1df099ced0247b