### PR TITLE
feat: add legal pages and booking links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,9 @@ import {
   Star,
   ArrowRight,
   Bot,
+  Scale,
+  Lock,
+  Key,
 } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
@@ -116,12 +119,19 @@ export default function AskMyAPTLanding() {
               </p>
               <div className="mt-8">
                 <Button
+                  asChild
                   size="lg"
                   className="bg-amber-600 hover:bg-amber-700 text-white text-lg px-8 py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
                   data-cta="hero-primary"
                 >
-                  Book a demo
-                  <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+                  <Link
+                    href="https://calendly.com/soya-myhoneybot"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Book a demo
+                    <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+                  </Link>
                 </Button>
               </div>
             </div>
@@ -343,8 +353,18 @@ export default function AskMyAPTLanding() {
                       </li>
                     ))}
                   </ul>
-                  <Button className={`w-full rounded-2xl ${plan.popular ? "bg-indigo-600 hover:bg-indigo-700" : "bg-gray-900 hover:bg-gray-800"} text-white`} data-cta="pricing-primary">
-                    Book a demo
+                  <Button
+                    asChild
+                    className={`w-full rounded-2xl ${plan.popular ? "bg-indigo-600 hover:bg-indigo-700" : "bg-gray-900 hover:bg-gray-800"} text-white`}
+                    data-cta="pricing-primary"
+                  >
+                    <Link
+                      href="https://calendly.com/soya-myhoneybot"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Book a demo
+                    </Link>
                   </Button>
                 </CardContent>
               </Card>
@@ -396,13 +416,22 @@ export default function AskMyAPTLanding() {
 
       {/* Risk & Trust */}
       <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl sm:text-4xl font-bold text-zinc-900 mb-6 text-center">Built for multifamily, ready for compliance</h2>
-          <ul className="space-y-4 text-zinc-700">
-            <li>Fair Housing-aware replies with human oversight</li>
-            <li>Encryption in transit & at rest</li>
-            <li>SSO and audit logging available</li>
-          </ul>
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-3xl sm:text-4xl font-bold text-zinc-900 mb-10 text-center">Built for multifamily, ready for compliance</h2>
+          <div className="grid gap-8 sm:grid-cols-3">
+            <div className="flex flex-col items-center text-center">
+              <Scale className="h-12 w-12 text-indigo-600 mb-4" />
+              <p className="text-zinc-700">Fair Housing-aware replies with human oversight</p>
+            </div>
+            <div className="flex flex-col items-center text-center">
+              <Lock className="h-12 w-12 text-indigo-600 mb-4" />
+              <p className="text-zinc-700">Encryption in transit & at rest</p>
+            </div>
+            <div className="flex flex-col items-center text-center">
+              <Key className="h-12 w-12 text-indigo-600 mb-4" />
+              <p className="text-zinc-700">SSO and audit logging available</p>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -412,15 +441,22 @@ export default function AskMyAPTLanding() {
           <h2 className="text-3xl sm:text-4xl font-bold text-white mb-6">Ready to automate leasing?</h2>
           <p className="text-xl text-indigo-100 mb-8">It only takes 15 minutes to see it in action.</p>
           <div>
-          <Button
-            size="lg"
-            className="bg-amber-600 hover:bg-amber-700 text-white text-lg px-8 py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
-            data-cta="closing-primary"
-          >
-            Book a demo
-            <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
-          </Button>
-        </div>
+            <Button
+              asChild
+              size="lg"
+              className="bg-amber-600 hover:bg-amber-700 text-white text-lg px-8 py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300"
+              data-cta="closing-primary"
+            >
+              <Link
+                href="https://calendly.com/soya-myhoneybot"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Book a demo
+                <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+              </Link>
+            </Button>
+          </div>
       </div>
     </section>
   </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - AskMyAPT",
+  description: "Privacy policy for AskMyAPT",
+}
+
+export default function PrivacyPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h1 className="text-3xl font-bold text-zinc-900 mb-8">Privacy Policy</h1>
+      <p className="text-zinc-700 mb-4">
+        Your privacy is important to us. This policy explains what information
+        we collect, how we use it, and the choices you have about your data.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Information We Collect</h2>
+      <p className="text-zinc-700 mb-4">
+        We collect information you provide directly, such as contact details and
+        messages you send us. We also gather limited technical data like your IP
+        address and browser settings to help us improve the service.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">How We Use Information</h2>
+      <p className="text-zinc-700 mb-4">
+        The information we collect is used to operate and enhance AskMyAPT,
+        provide customer support, and communicate updates. We do not sell your
+        personal data to third parties.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Sharing of Information</h2>
+      <p className="text-zinc-700 mb-4">
+        We may share your information with trusted service providers who assist
+        us in running the platform. These providers are obligated to safeguard
+        your data and use it only for the purposes we specify.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Cookies</h2>
+      <p className="text-zinc-700 mb-4">
+        Cookies help us remember your preferences and understand how you use the
+        site. You can disable cookies through your browser settings, but some
+        features may not function properly.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Data Security</h2>
+      <p className="text-zinc-700 mb-4">
+        We implement reasonable safeguards to protect your information from
+        unauthorized access or disclosure. However, no method of transmission is
+        completely secure, and we cannot guarantee absolute security.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Changes to This Policy</h2>
+      <p className="text-zinc-700 mb-4">
+        We may update this policy from time to time. If we make significant
+        changes, we will notify you by posting the revised policy on this page
+        with a new effective date.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Contact Us</h2>
+      <p className="text-zinc-700">
+        If you have questions about this policy or our practices, please contact
+        us at support@askmyapt.com.
+      </p>
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -10,5 +10,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: "https://askmyapt.com/contact",
       lastModified: new Date(),
     },
+    {
+      url: "https://askmyapt.com/terms",
+      lastModified: new Date(),
+    },
+    {
+      url: "https://askmyapt.com/privacy",
+      lastModified: new Date(),
+    },
   ]
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Terms of Service - AskMyAPT",
+  description: "Terms of Service for AskMyAPT",
+}
+
+export default function TermsPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h1 className="text-3xl font-bold text-zinc-900 mb-8">Terms of Service</h1>
+      <p className="text-zinc-700 mb-4">
+        These Terms govern your use of AskMyAPT. By accessing or using the
+        service, you agree to be bound by them.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Use of Service</h2>
+      <p className="text-zinc-700 mb-4">
+        You may use the platform only in compliance with these Terms and all
+        applicable laws. You are responsible for the content you submit and for
+        maintaining the security of your account.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Accounts</h2>
+      <p className="text-zinc-700 mb-4">
+        When you create an account, you must provide accurate information and
+        keep it up to date. You are responsible for any activity that occurs
+        under your credentials and should notify us of any unauthorized use.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Intellectual Property</h2>
+      <p className="text-zinc-700 mb-4">
+        All content and materials on AskMyAPT are the property of AskMyAPT Inc.
+        or its licensors and are protected by copyright and other laws. You may
+        not copy, modify, or distribute any part of the service without written
+        permission.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Termination</h2>
+      <p className="text-zinc-700 mb-4">
+        We may suspend or terminate your access to the service at any time if
+        you violate these Terms or for any other reason. Upon termination, your
+        right to use the service will cease immediately.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Disclaimer</h2>
+      <p className="text-zinc-700 mb-4">
+        The service is provided on an "as is" and "as available" basis without
+        warranties of any kind, either express or implied. AskMyAPT disclaims
+        all warranties including merchantability, fitness for a particular
+        purpose, and non-infringement.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Limitation of Liability</h2>
+      <p className="text-zinc-700 mb-4">
+        To the fullest extent permitted by law, AskMyAPT shall not be liable for
+        any indirect, incidental, or consequential damages arising out of your
+        use or inability to use the service.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Changes to These Terms</h2>
+      <p className="text-zinc-700 mb-4">
+        We may modify these Terms from time to time. If we make material
+        changes, we will post the revised Terms on this page with an updated
+        effective date. Your continued use of the service constitutes acceptance
+        of the new Terms.
+      </p>
+
+      <h2 className="text-xl font-semibold text-zinc-900 mt-8 mb-4">Contact</h2>
+      <p className="text-zinc-700">
+        If you have any questions about these Terms, please contact us at
+        support@askmyapt.com.
+      </p>
+    </div>
+  )
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -8,20 +8,14 @@ export function Footer() {
           <Link href="/" className="text-2xl font-bold text-indigo-600 mb-4 md:mb-0">
             AskMyAPT
           </Link>
-          <nav aria-label="Footer" className="flex space-x-6 mb-4 md:mb-0">
-            <Link href="#" className="text-zinc-600 hover:text-zinc-900 transition-colors">
-              Terms
-            </Link>
-            <Link href="#" className="text-zinc-600 hover:text-zinc-900 transition-colors">
-              Privacy
-            </Link>
-            <Link href="#" className="text-zinc-600 hover:text-zinc-900 transition-colors">
-              Security
-            </Link>
-            <Link href="/contact" className="text-zinc-600 hover:text-zinc-900 transition-colors">
-              Contact
-            </Link>
-          </nav>
+            <nav aria-label="Footer" className="flex space-x-6 mb-4 md:mb-0">
+              <Link href="/terms" className="text-zinc-600 hover:text-zinc-900 transition-colors">
+                Terms
+              </Link>
+              <Link href="/privacy" className="text-zinc-600 hover:text-zinc-900 transition-colors">
+                Privacy
+              </Link>
+            </nav>
         </div>
         <div className="mt-8 pt-8 border-t border-gray-200 text-center">
           <p className="text-zinc-500 text-sm">© 2025 AskMyAPT Inc. All rights reserved.</p>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -35,9 +35,17 @@ export function Header() {
             </Link>
           ))}
         </nav>
-        <div className="hidden md:block">
-          <Button className="bg-amber-600 hover:bg-amber-700 text-white" data-cta="header-primary">Book a demo</Button>
-        </div>
+          <div className="hidden md:block">
+            <Button asChild className="bg-amber-600 hover:bg-amber-700 text-white" data-cta="header-primary">
+              <Link
+                href="https://calendly.com/soya-myhoneybot"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Book a demo
+              </Link>
+            </Button>
+          </div>
         <div className="md:hidden">
           <Sheet open={open} onOpenChange={setOpen}>
             <SheetTrigger asChild>
@@ -63,9 +71,20 @@ export function Header() {
                     {item.label}
                   </Link>
                 ))}
-                <Button className="bg-amber-600 hover:bg-amber-700 text-white" onClick={() => setOpen(false)} data-cta="header-primary">
-                  Book a demo
-                </Button>
+                  <Button
+                    asChild
+                    className="bg-amber-600 hover:bg-amber-700 text-white"
+                    data-cta="header-primary"
+                  >
+                    <Link
+                      href="https://calendly.com/soya-myhoneybot"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => setOpen(false)}
+                    >
+                      Book a demo
+                    </Link>
+                  </Button>
               </div>
             </SheetContent>
           </Sheet>

--- a/components/IntegrationsStrip.tsx
+++ b/components/IntegrationsStrip.tsx
@@ -1,48 +1,44 @@
-import Image from "next/image"
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 
-const logos = [
+const integrations = [
   {
-    src: "/integrations/appfolio.svg",
-    alt: "AppFolio logo",
-    text: "AppFolio • sync availability & pricing",
+    name: "AppFolio",
+    description: "Sync availability & pricing",
   },
   {
-    src: "/integrations/buildium.svg",
-    alt: "Buildium logo",
-    text: "Buildium • sync availability & pricing",
+    name: "Buildium",
+    description: "Sync availability & pricing",
   },
   {
-    src: "/integrations/yardi.svg",
-    alt: "Yardi logo",
-    text: "Yardi • push tours & log leads",
+    name: "Yardi",
+    description: "Push tours & log leads",
   },
   {
-    src: "/integrations/google-calendar.svg",
-    alt: "Google Calendar logo",
-    text: "Google Calendar • real-time scheduling",
+    name: "Google Calendar",
+    description: "Real-time scheduling",
   },
   {
-    src: "/integrations/twilio.svg",
-    alt: "Twilio logo",
-    text: "Twilio • SMS & handoff",
+    name: "Twilio",
+    description: "SMS & handoff",
   },
   {
-    src: "/integrations/hubspot.svg",
-    alt: "HubSpot logo",
-    text: "HubSpot • lead capture & tracking",
+    name: "HubSpot",
+    description: "Lead capture & tracking",
   },
 ]
 
 export function IntegrationsStrip() {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8 items-center">
-      {logos.map((logo) => (
-        <div key={logo.src} className="flex items-center justify-center">
-          <div className="text-center">
-            <Image src={logo.src} alt={logo.alt} width={120} height={40} loading="lazy" />
-            <p className="mt-2 text-sm text-zinc-600">{logo.text}</p>
-          </div>
-        </div>
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {integrations.map((integration) => (
+        <Card key={integration.name} className="text-center">
+          <CardHeader className="items-center p-4 text-center">
+            <CardTitle className="text-base font-medium">
+              {integration.name}
+            </CardTitle>
+            <CardDescription>{integration.description}</CardDescription>
+          </CardHeader>
+        </Card>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- replace integration logos with text-only cards
- revamp compliance section with icon grid
- add terms and privacy pages and remove security/contact links from footer
- point all “Book a demo” buttons to Calendly
- flesh out Terms of Service and Privacy Policy content

## Testing
- `pnpm lint` *(fails: prompts for ESLint setup)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689d1d9aa4c883219d1df099ced0247b