### PR TITLE
feat: add demo confirmation page

### DIFF
--- a/app/demo-confirmed/page.tsx
+++ b/app/demo-confirmed/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Demo Confirmed - AskMyAPT",
+  description: "Confirmation page for scheduled demo",
+}
+
+export default function DemoConfirmedPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+      <h1 className="text-3xl font-bold text-zinc-900 mb-8">Demo Confirmed</h1>
+      <p className="text-zinc-700">
+        Thanks for booking a demo. You'll receive the meeting details via email shortly.
+      </p>
+    </div>
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,6 +11,10 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: new Date(),
     },
     {
+      url: "https://askmyapt.com/demo-confirmed",
+      lastModified: new Date(),
+    },
+    {
       url: "https://askmyapt.com/terms",
       lastModified: new Date(),
     },


### PR DESCRIPTION
## Summary
- add demo confirmation page shown after booking
- include demo confirmation page in sitemap

## Testing
- `pnpm build`
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689fdcc31c188321a63607ee878dce44