### PR TITLE
Specify supported languages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,7 +78,7 @@ const faqLd = {
       name: "Does AskMyAPT support multiple languages?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "It can chat with prospects in over 100 languages.",
+        text: "It can chat with prospects in English, Spanish, and French.",
       },
     },
   ],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ export default function AskMyAPTLanding() {
     {
       icon: Globe,
       title: "Multilingual by default",
-      description: "Welcome prospects in their language.",
+      description: "Supports English, Spanish, and French.",
     },
     {
       icon: Users,

--- a/components/ChatDemo.tsx
+++ b/components/ChatDemo.tsx
@@ -10,7 +10,7 @@ const faq: Record<string, string> = {
   "Do you allow pets?": "Yes, we're pet-friendly! We welcome cats and dogs with a $300 deposit.",
   "Can I book a tour?": "Absolutely—just let us know a day and time that works for you.",
   "How much is rent?": "Two-bedroom units start at $1,850 per month.",
-  "Do you support other languages?": "Yes, AskMyAPT can chat in over 100 languages.",
+  "Do you support other languages?": "Yes, AskMyAPT supports English, Spanish, and French.",
   "What about after-hours?": "Our assistant responds to leads 24/7, even after your office closes.",
   "How do maintenance requests work?": "Maintenance issues are routed to the right team automatically.",
 }


### PR DESCRIPTION
## Summary
- Clarify language support feature as English, Spanish, and French
- Update FAQ demo prompt to list English, Spanish, and French
- Adjust structured data FAQ answer for specific languages

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689fe8697888832192fc2add1f419eaa