### PR TITLE
feat: change CTA text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -182,7 +182,7 @@ export default function AskMyAPTLanding() {
                   data-cta="hero-primary"
                 >
                   <Link href="https://calendly.com/soya-myhoneybot">
-                    Book a demo
+                    See It in Action
                     <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
                   </Link>
                 </Button>
@@ -474,9 +474,9 @@ export default function AskMyAPTLanding() {
                     data-cta="pricing-primary"
                   >
                     <Link href="https://calendly.com/soya-myhoneybot">
-                      Book a demo
+                      See It in Action
                     </Link>
-                  </Button>
+                 </Button>
                 </CardContent>
               </Card>
             ))}
@@ -588,7 +588,7 @@ export default function AskMyAPTLanding() {
               data-cta="closing-primary"
             >
               <Link href="https://calendly.com/soya-myhoneybot">
-                Book a demo
+                See It in Action
                 <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
               </Link>
             </Button>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -38,7 +38,7 @@ export function Header() {
           <div className="hidden md:block">
             <Button asChild className="bg-amber-600 hover:bg-amber-700 text-white" data-cta="header-primary">
               <Link href="https://calendly.com/soya-myhoneybot">
-                Book a demo
+                See It in Action
               </Link>
             </Button>
           </div>
@@ -76,7 +76,7 @@ export function Header() {
                       href="https://calendly.com/soya-myhoneybot"
                       onClick={() => setOpen(false)}
                     >
-                      Book a demo
+                      See It in Action
                     </Link>
                   </Button>
               </div>


### PR DESCRIPTION
## Summary
- replace "Book a demo" with "See It in Action" across hero, pricing, final call-to-action, and header buttons

## Testing
- `pnpm lint` *(fails: requires interactive ESLint configuration)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2922ef82c83218801358526eef309